### PR TITLE
feat: add location to ctx

### DIFF
--- a/src/contentscript/modules/dynamic-adapter/widgets.ts
+++ b/src/contentscript/modules/dynamic-adapter/widgets.ts
@@ -275,6 +275,8 @@ export class WidgetBuilder {
       const ctx = this.contextBuilder(el, parent)
       if (!ctx) return null
       ctx.parent = parent
+      const { host, hostname, href, origin, pathname, port, protocol } = document.location
+      ctx.location = { host, hostname, href, origin, pathname, port, protocol }
       return ctx
     } catch (err) {
       // ToDo: what need to do in this cases?


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to an item)

[x] New feature

#### What changes did you make? (Give an overview)

In some cases (for example, for Tipping on GitHub) we need to know the URL and its details for the context. Document object is not available in dapplets. But we can get the useful location information through the ctx variable.