### PR TITLE
An empty log in pop-up (DAP-4097)

### DIFF
--- a/src/background/services/sessionService.ts
+++ b/src/background/services/sessionService.ts
@@ -96,12 +96,17 @@ export class SessionService {
   async createSession(
     moduleName: string,
     request: LoginRequest,
-    tabId: number
+    tabId: number,
+    wasError?: {
+      creatingLoginConfirmationFailed: boolean
+    }
   ): Promise<LoginSession> {
+    console.log('wasError', wasError)
     request.timeout = request.timeout ?? DEFAULT_REQUEST_TIMEOUT
     request.secureLogin = request.secureLogin ?? SecureLoginOptions.Disabled
     request.reusePolicy = request.reusePolicy ?? ReusePolicyOptions.Disabled
     request.from = request.from ?? LoginRequestFromOptions.Any
+    if (wasError?.creatingLoginConfirmationFailed) request.creatingLoginConfirmationFailed = true
 
     if (!request.authMethods || request.authMethods.length === 0) {
       throw new Error(`"authMethods" is required.`)
@@ -132,11 +137,15 @@ export class SessionService {
       }
     }
 
+    console.log('moduleName', moduleName)
+    console.log('request', request)
+    console.log('tabId', tabId)
     const overlayResult = await this._overlayService.openLoginSessionOverlay(
       moduleName,
       request,
       tabId
     )
+    console.log('overlayResult', overlayResult)
 
     const { wallet, chain } = overlayResult
     let { confirmationId } = overlayResult
@@ -182,6 +191,10 @@ export class SessionService {
           chain,
           wallet
         )
+        if (!loginConfirmation)
+          this.createSession(moduleName, request, tabId, {
+            creatingLoginConfirmationFailed: !loginConfirmation,
+          })
         confirmationId = loginConfirmation.loginConfirmationId
       }
     }
@@ -232,10 +245,12 @@ export class SessionService {
         throw new Error('The parameter `contractId` is required for secure login in NEAR Protocol')
       }
 
-      await (genericWallet as NearWallet).createAccessKey(
+      const isSuccessfulResult = await (genericWallet as NearWallet).createAccessKey(
         request.contractId,
         loginConfirmation.loginConfirmationId
       )
+
+      if (!isSuccessfulResult) return null
 
       loginConfirmation.address = await genericWallet.getAddress()
       loginConfirmation.contractId = request.contractId

--- a/src/background/services/sessionService.ts
+++ b/src/background/services/sessionService.ts
@@ -101,7 +101,6 @@ export class SessionService {
       creatingLoginConfirmationFailed: boolean
     }
   ): Promise<LoginSession> {
-    console.log('wasError', wasError)
     request.timeout = request.timeout ?? DEFAULT_REQUEST_TIMEOUT
     request.secureLogin = request.secureLogin ?? SecureLoginOptions.Disabled
     request.reusePolicy = request.reusePolicy ?? ReusePolicyOptions.Disabled
@@ -137,15 +136,11 @@ export class SessionService {
       }
     }
 
-    console.log('moduleName', moduleName)
-    console.log('request', request)
-    console.log('tabId', tabId)
     const overlayResult = await this._overlayService.openLoginSessionOverlay(
       moduleName,
       request,
       tabId
     )
-    console.log('overlayResult', overlayResult)
 
     const { wallet, chain } = overlayResult
     let { confirmationId } = overlayResult
@@ -192,7 +187,7 @@ export class SessionService {
           wallet
         )
         if (!loginConfirmation)
-          this.createSession(moduleName, request, tabId, {
+          return this.createSession(moduleName, request, tabId, {
             creatingLoginConfirmationFailed: !loginConfirmation,
           })
         confirmationId = loginConfirmation.loginConfirmationId

--- a/src/background/wallets/near/interface.ts
+++ b/src/background/wallets/near/interface.ts
@@ -36,5 +36,5 @@ export interface NearWallet extends GenericWallet {
   signAndSendTransactions(params: any): Promise<void> // ToDo: add types
   buildImportAccountsUrl(): string
   getAccount(): Promise<CustomConnectedWalletAccount>
-  createAccessKey(contractId: string, loginConfirmationId: string): Promise<void>
+  createAccessKey(contractId: string, loginConfirmationId: string): Promise<boolean>
 }

--- a/src/background/wallets/near/near/index.ts
+++ b/src/background/wallets/near/near/index.ts
@@ -176,7 +176,7 @@ export default class implements NearWallet {
     await this._connectBrowserWallet(_state.wallet)
   }
 
-  async createAccessKey(contractId: string, loginConfirmationId: string): Promise<void> {
+  async createAccessKey(contractId: string, loginConfirmationId: string): Promise<boolean> {
     /*
         The `near-api-js` library does not support multiple access keys at the same time. 
         When you try to create a second access key with the specified contract 
@@ -208,7 +208,7 @@ export default class implements NearWallet {
 
     const nearWallet = new CustomWalletConnection(near, authData, authDataKey)
 
-    await this._connectBrowserWallet(nearWallet, contractId)
+    return this._connectBrowserWallet(nearWallet, contractId)
   }
 
   async disconnectWallet() {
@@ -232,7 +232,10 @@ export default class implements NearWallet {
     throw new NotImplementedError()
   }
 
-  private async _connectBrowserWallet(nearWallet: CustomWalletConnection, contractId?: string) {
+  private async _connectBrowserWallet(
+    nearWallet: CustomWalletConnection,
+    contractId?: string
+  ): Promise<boolean> {
     // ToDo: why this function became async?
     const expectedAccountId = await nearWallet.getAccountId()
 
@@ -272,16 +275,18 @@ export default class implements NearWallet {
     if (!accountId) throw new Error('No account_id params in callback URL')
 
     if (expectedAccountId !== '' && contractId && expectedAccountId !== accountId) {
-      throw new Error(
-        `Account ${truncateEthAddress(expectedAccountId)} was expected, but ${truncateEthAddress(
-          accountId,
-          24
-        )} is connected`
+      console.log(
+        `Account ${truncateEthAddress(
+          expectedAccountId,
+          30
+        )} was expected, but ${truncateEthAddress(accountId, 30)} is connected`
       )
+      return false
     }
 
-    nearWallet.completeSignIn(accountId, publicKey, allKeys) // ToDo: need to wait promise?
-    browser.storage.local.set({ [this._lastUsageKey]: new Date().toISOString() })
+    await nearWallet.completeSignIn(accountId, publicKey, allKeys) // ToDo: need to wait promise?
+    await browser.storage.local.set({ [this._lastUsageKey]: new Date().toISOString() })
+    return true
   }
 
   private async _setupWalletState() {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -112,6 +112,7 @@ export type LoginRequest = {
   reusePolicy?: ReusePolicyOptions | ValueOf<ReusePolicyOptions>
   from?: LoginRequestFromOptions | ValueOf<LoginRequestFromOptions>
   contractId?: string // ToDo: rethink this parameter, needed for NEAR only
+  creatingLoginConfirmationFailed?: boolean
 }
 
 export enum SecureLoginOptions {

--- a/src/contentscript/overlay/root/components/SystemPopup/components/Base.module.scss
+++ b/src/contentscript/overlay/root/components/SystemPopup/components/Base.module.scss
@@ -91,3 +91,9 @@
     margin-bottom: 5px;
   }
 }
+
+.warningMessage {
+  margin: 16px 1rem -10px;
+  color: #d9304f;
+  text-indent: 1rem;
+}

--- a/src/contentscript/overlay/root/components/SystemPopup/components/Overlay/Overlay.module.scss
+++ b/src/contentscript/overlay/root/components/SystemPopup/components/Overlay/Overlay.module.scss
@@ -55,7 +55,7 @@
 }
 
 .body {
-  height: 100%;
+  height: calc(100% - 20px);
 }
 
 .body > div {

--- a/src/contentscript/overlay/root/components/SystemPopup/pages/login-session/ConnectedWallets.tsx
+++ b/src/contentscript/overlay/root/components/SystemPopup/pages/login-session/ConnectedWallets.tsx
@@ -140,15 +140,9 @@ export class ConnectedWallets extends React.Component<Props, State> {
         )}
 
         {creatingLoginConfirmationFailed && (
-          <p
-            style={{
-              marginTop: '1.5rem',
-              padding: '0 1rem',
-              color: '#d9304f',
-            }}
-          >
+          <p className={base.warningMessage}>
             Connect a wallet that is already connected to the Dapplets extension. If you want to log
-            in with a different wallet, first connect it to the extension in the Wallets module.
+            in with another wallet, first connect it to the extension in the Wallets module.
           </p>
         )}
 

--- a/src/contentscript/overlay/root/components/SystemPopup/pages/login-session/ConnectedWallets.tsx
+++ b/src/contentscript/overlay/root/components/SystemPopup/pages/login-session/ConnectedWallets.tsx
@@ -58,8 +58,13 @@ export class ConnectedWallets extends React.Component<Props, State> {
   }
 
   async selectWallet(wallet: string, chain: string) {
-    const frameId = this.props.data.frameId
-    this.props.bus.publish('ready', [frameId, { wallet, chain }])
+    try {
+      const frameId = this.props.data.frameId
+      this.props.bus.publish('ready', [frameId, { wallet, chain }])
+      await this.componentDidMount()
+    } catch (err) {
+      this.setState({ error: err.message })
+    }
   }
 
   async loginWallet(wallet: string, chain: string) {
@@ -81,7 +86,8 @@ export class ConnectedWallets extends React.Component<Props, State> {
     const s = this.state
 
     const chains = this.props.data.loginRequest.authMethods
-    const { secureLogin, reusePolicy } = this.props.data.loginRequest
+    const { secureLogin, reusePolicy, creatingLoginConfirmationFailed } =
+      this.props.data.loginRequest
 
     if (s.error) {
       return (
@@ -131,6 +137,19 @@ export class ConnectedWallets extends React.Component<Props, State> {
           <p className={base.subtitle}>Select connected wallet to sign a new login confirmation</p>
         ) : (
           <p className={base.subtitle}>Select connected wallet to log in</p>
+        )}
+
+        {creatingLoginConfirmationFailed && (
+          <p
+            style={{
+              marginTop: '1.5rem',
+              padding: '0 1rem',
+              color: '#d9304f',
+            }}
+          >
+            Connect a wallet that is already connected to the Dapplets extension. If you want to log
+            in with a different wallet, first connect it to the extension in the Wallets module.
+          </p>
         )}
 
         <ul className={base.list}>

--- a/src/worker/core/index.ts
+++ b/src/worker/core/index.ts
@@ -499,8 +499,14 @@ export class Core {
     delete _request.onLogout
 
     const { createSession, getThisTab } = initBGFunctions()
-    const thisTab = await getThisTab()
-    const session = await createSession(moduleName, _request, thisTab.id)
+    let session = null
+    try {
+      const thisTab = await getThisTab()
+      session = await createSession(moduleName, _request, thisTab.id)
+    } catch (err) {
+      console.log('Error during creating a session:', err)
+      return null
+    }
 
     const ls = {} // ToDo: specify LoginInfo
     onLogin?.call({}, ls)


### PR DESCRIPTION
Fix: the log in process is failed when the user try to connect to the dapplet a different wallet, than was connected to the extension (DAP-4097).
